### PR TITLE
simplify bot configuration

### DIFF
--- a/cmd/bot/BUILD.bazel
+++ b/cmd/bot/BUILD.bazel
@@ -28,9 +28,6 @@ container_image(
     env = {
         "BOT_ID": "",
         "BOT_KEY": "",
-        "BOT_CLIENT_ID": "",
-        "BOT_CLIENT_SECRET": "",
-        "BOT_INSTALLATION_ID": "",
     },
     labels = labels({"org.opencontainers.image.description": "GitHub bot"}),
 )

--- a/cmd/bot/action.yml
+++ b/cmd/bot/action.yml
@@ -7,15 +7,6 @@ inputs:
   bot-key:
     description: "Bot private key"
     required: true
-  bot-installation-id:
-    description: "Bot installation ID"
-    required: true
-  bot-client-id:
-    description: "Bot client ID"
-    required: true
-  bot-client-secret:
-    description: "Bot client secret"
-    required: true
 outputs:
   token:
     description: "An authentication token"

--- a/cmd/bot/index.ts
+++ b/cmd/bot/index.ts
@@ -26,8 +26,8 @@ async function main() {
 
   const {
     data: { id: installationId },
-  } = await octo.request('GET /repos/{repository}/installation', {
-    repository: env.GITHUB_REPOSITORY
+  } = await octo.request("GET /repos/{repository}/installation", {
+    repository: env.GITHUB_REPOSITORY,
   });
 
   const auth = await octo.apps.createInstallationAccessToken({

--- a/cmd/bot/index.ts
+++ b/cmd/bot/index.ts
@@ -4,10 +4,8 @@ import { Octokit } from "@octokit/rest";
 interface IEnv {
   BOT_ID: string;
   BOT_KEY: string;
-  BOT_INSTALLATION_ID: string;
-  BOT_CLIENT_ID: string;
-  BOT_CLIENT_SECRET: string;
   CHECK: string;
+  GITHUB_REPOSITORY: string;
 }
 
 async function main() {
@@ -23,14 +21,17 @@ async function main() {
     auth: {
       id: Number(env.BOT_ID),
       privateKey: env.BOT_KEY,
-      installationId: Number(env.BOT_INSTALLATION_ID),
-      clientId: env.BOT_CLIENT_ID,
-      clientSecret: env.BOT_CLIENT_SECRET,
     },
   });
 
+  const {
+    data: { id: installationId },
+  } = await octo.request('GET /repos/{repository}/installation', {
+    repository: env.GITHUB_REPOSITORY
+  });
+
   const auth = await octo.apps.createInstallationAccessToken({
-    installation_id: Number(env.BOT_INSTALLATION_ID),
+    installation_id: Number(installationId),
   });
 
   console.log(`::set-output name=token::${auth.data.token}`);


### PR DESCRIPTION
replaces #629 with a branch in this repo instead of the fork.

This drops 3 of the parameters for configuring github app auth.

Prior art at

- https://github.com/machine-learning-apps/actions-app-token/blob/2d92b2a2bb7030dca3dd14975ae44799debed2e8/token_getter.py#L80
- https://github.com/getsentry/action-github-app-token/blob/8643d5333ffa9568aa96a23606b6f453a8b84211/src/main.ts#L17
- https://github.com/tibdex/github-app-token/blob/85a43856db63fbb47ba4a5dac7584446c5e6d8e1/src/fetch-installation-token.ts#L19