### PR TITLE
github: don't check label on PR open

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -6,7 +6,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-      - opened
       - reopened
 
 jobs:


### PR DESCRIPTION
Hopefully this avoids a race where:

1. A PR is opened with no labels.
2. This check receives the `opened` payload and starts to process it.
3. Before (2) completes, a label is applied to the PR.
4. After (3) is processed, (2) completes and marks the PR failed because it had no label.

This only makes sense when `lint / github` is a required check on a protected branch. Then, the UI will block a merge until the check runs when the PR gets a label. Otherwise, the check may never run and a PR will be allowed to merge nonetheless.