### PR TITLE
test: run full suite outside push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,8 +30,6 @@ jobs:
         with:
           python-version: "3.7"
       - run: .github/matchers.sh
-      - name: bazel test
-        run: ./tools/bazel test --config=ci //...
       - name: docker login ghcr.io
         run: echo "$DOCKER_TOKEN" | docker login --password-stdin --username "$DOCKER_USER" ghcr.io
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: test
 
 on:
   push:
-    branches-ignore:
-      - main
 
 jobs:
   test:
@@ -15,4 +13,4 @@ jobs:
           python-version: "3.7"
       - run: .github/matchers.sh
       - name: bazel test
-        run: ./tools/bazel test --config=ci --config=fast //...
+        run: ./tools/bazel test --config=ci ${GITHUB_HEAD_REF:---config=fast} //...


### PR DESCRIPTION
Run tests on all pushes.

If GITHUB_HEAD_REF is set, we're testing a PR and can run with the
fast config.